### PR TITLE
Add Travis + badges + precommit hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+node_js:
+  - '8'
+
+cache:
+  directories:
+    - node_modules
+
+install:
+  - npm install
+
+script:
+  - npm run test
+
+after_success:
+  # - npm run coverage
+
+branches:
+  only:
+    - master

--- a/README.md
+++ b/README.md
@@ -1,6 +1,25 @@
 # ProxyPack
 
-ProxyPack is WebPack Plugin that allows you to serve Local Assets to a Production Website.
+[![Build Status](https://travis-ci.org/helpscout/proxypack.svg?branch=master)](https://travis-ci.org/helpscout/proxypack)
+[![npm version](https://badge.fury.io/js/%40helpscout%2Fproxypack.svg)](https://badge.fury.io/js/%40helpscout%2Fproxypack)
+
+> ProxyPack is WebPack Plugin that allows you to serve Local Assets to a Production Website
+
+## Table of Contents
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [Webpack Setup](#webpack-setup)
+  - [Example 1:](#example-1)
+- [External Mappings:](#external-mappings)
+  - [Install SSL Certificate](#install-ssl-certificate)
+- [To View A Proxy Build](#to-view-a-proxy-build)
+  - [Launcher Method](#launcher-method)
+  - [Standalone Method](#standalone-method)
+- [Thanks](#thanks)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Webpack Setup
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format": "zero format",
     "lint": "zero lint",
     "release": "zero release",
+    "precommit": "zero pre-commit",
     "test": "zero test --coverage",
     "validate": "zero validate"
   },


### PR DESCRIPTION
## Add Travis + badges + precommit hook

This update sets up proxypack with Travis. Badges for travis and npm were
added to the README.md.

Lastly, Zero's `pre-commit` hook was added back into the dev workflow.