### PR TITLE
Fix horizontal scrolling on proxied pages

### DIFF
--- a/src/proxyServer.js
+++ b/src/proxyServer.js
@@ -22,7 +22,7 @@ class ProxyServer {
     this.webpackAssets = {}
     this.mappings = mappings
     this.warningMessage = [
-      '<div style="display: block; text-align: center; padding: 7px; width: 100%; background-color: #ffcc00; color: #000000; border-top: 1px solid #fff;">',
+      '<div style="display: block; text-align: center; padding: 7px; width: 100%; background-color: #ffcc00; color: #000000; border-top: 1px solid #fff; box-sizing: border-box;">',
       '🎭 This browser is connected to ProxyPack and some files might be coming from alternative sources.',
       '</div>',
     ]


### PR DESCRIPTION
This update fixes an issue where the banner injected into pages by ProxyPack would exceed the width of the page by 14px causing horizontal scrolling.

![Problem](http://c.hlp.sc/39791df3c83f/Image%2525202019-03-18%252520at%25252011.11.15%252520AM.png)

By setting the `box-sizing` property to `border-box`, the 14 pixels of padding along the x-axis are subtracted from the width instead of added to it. This removes the 14px of padding on the right of the page that was causing horizontal scrolling.

![Solution](http://c.hlp.sc/e42f604261f7/Image%2525202019-03-18%252520at%25252011.12.29%252520AM.png)