### PR TITLE
Don't add CSP headers if they don't exist

### DIFF
--- a/src/proxyServer/interceptors/domain.js
+++ b/src/proxyServer/interceptors/domain.js
@@ -61,12 +61,15 @@ function init() {
           type: 'domain',
         })
 
-        const policy = new Policy(response.headers['content-security-policy'])
-        policy.add('script-src', localWebpackServerURL)
+        const currentPolicy = response.headers['content-security-policy']
 
-        // hack the CSP header
-        // see https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP
-        response.headers['content-security-policy'] = policy.toString()
+        // if a CSP Header exists we merge our localWebpackServerURL into it
+        if (currentPolicy) {
+          const policy = new Policy(response.headers['content-security-policy'])
+          policy.add('script-src', localWebpackServerURL)
+          response.headers['content-security-policy'] = policy.toString()
+        }
+
         // proxypack custom headers
         // response.statusCode = 203
         response.headers['proxypack-interceptor-type'] = 'domain'


### PR DESCRIPTION
Previously we we're creating CSP headers, even they didn't exist on the previous request.
https://github.com/helpscout/proxypack/compare/v0.1.7...v0.1.8

In this fix, we first check if the headers exist before merging them in. This would means that since the local domain works without the header that CSP is OptIn, and hence we only need to add it when it has already been added.