### PR TITLE
Add overwrite public url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7887,6 +7887,32 @@
         }
       }
     },
+    "firefox-launch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/firefox-launch/-/firefox-launch-1.1.0.tgz",
+      "integrity": "sha1-c24XocOtsvDSeBdVpKDqSHBUnJU=",
+      "requires": {
+        "firefox-location": "^1.0.0",
+        "mkdirp": "^0.5.0",
+        "quick-tmp": "0.0.0",
+        "rimraf": "^2.2.8",
+        "shallow-copy": "0.0.1"
+      }
+    },
+    "firefox-location": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/firefox-location/-/firefox-location-1.0.2.tgz",
+      "integrity": "sha1-S+5a+TewR5Qf8glkTK/479MrK0c=",
+      "requires": {
+        "userhome": "^1.0.0",
+        "which": "^1.0.5"
+      }
+    },
+    "first-match": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/first-match/-/first-match-0.0.1.tgz",
+      "integrity": "sha1-pg7GQnAPD0NyNOu37D84JHblQv0="
+    },
     "flat-cache": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
@@ -14334,6 +14360,22 @@
       "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
+    "quick-tmp": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/quick-tmp/-/quick-tmp-0.0.0.tgz",
+      "integrity": "sha1-QWXmYyDqBfnLzM874fj9X9sF998=",
+      "requires": {
+        "first-match": "0.0.1",
+        "osenv": "0.0.3"
+      },
+      "dependencies": {
+        "osenv": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+          "integrity": "sha1-zWrY3bKQkVrZ4idlV2Al1BHynLY="
+        }
+      }
+    },
     "raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
@@ -15338,6 +15380,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -16868,6 +16915,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+    },
+    "userhome": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
+      "integrity": "sha1-tkkf8S0hpecmcd+czIcX4cZojAs="
     },
     "util": {
       "version": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "axios": "^0.18.0",
     "chalk": "^2.4.2",
     "csp-parse": "0.0.2",
+    "firefox-launch": "^1.1.0",
     "hoxy": "^3.3.1",
     "mime-types": "^2.1.24",
     "promise-fs": "^2.1.1",

--- a/src/browser/firefox.js
+++ b/src/browser/firefox.js
@@ -1,0 +1,31 @@
+var launchFirefox = require('firefox-launch')
+const { PROXY_PACK_CONFIG_DIR } = require('../constants/config')
+
+function openFirefox(domain) {
+  const pref = [
+    'user_pref("network.proxy.http", "localhost");',
+    'user_pref("network.proxy.http_port", 7777);',
+    'user_pref("network.proxy.ssl", "localhost");',
+    'user_pref("network.proxy.ssl_port", 7777);',
+    'user_pref("network.proxy.share_proxy_settings", true);',
+    'user_pref("network.proxy.type", 1);',
+    'user_pref("network.proxy.no_proxies_on", "");',
+    'user_pref("browser.shell.checkDefaultBrowser", false);',
+    'user_pref("browser.bookmarks.restore_default_bookmarks", false);',
+    'user_pref("dom.allow_scripts_to_close_windows", true);',
+  ].join('\n')
+
+  const args = ['-foreground']
+
+  const instance = launchFirefox(domain, {
+    args,
+    dir: `${PROXY_PACK_CONFIG_DIR}/firefox_profile`,
+    pref,
+  })
+
+  instance.on('close', () => {
+    // console.log('close')
+  })
+}
+
+module.exports = openFirefox

--- a/src/browser/openBrowser.js
+++ b/src/browser/openBrowser.js
@@ -1,37 +1,42 @@
 const launcher = require('@james-proxy/james-browser-launcher')
+const openFirefox = require('./firefox')
 
 function openBrowser({ browser, domain }) {
-  launcher(function(error, launch) {
-    if (error) {
-      console.error(error)
-      return
-    }
-    launch(
-      domain,
-      {
-        proxy: 'localhost:7777',
-        browser: browser,
-        detached: true,
-        options: ['--disable-web-security', '--ignore-certificate-errors'],
-      },
-      function(error, instance) {
-        if (error) {
-          console.error(error)
-          return
-        }
-        console.log(
-          `🎭 ProxyPack browser instance started for ${domain} in ${browser}.`,
-        )
-        // instance.process.unref()
-        // instance.process.stdin.unref()
-        // instance.process.stdout.unref()
-        // instance.process.stderr.unref()
-        instance.on('stop', function(code) {
-          console.log('Instance stopped with exit code:', code)
-        })
-      },
-    )
-  })
+  if (browser === 'firefox') {
+    openFirefox(domain)
+  } else {
+    launcher(function(error, launch) {
+      if (error) {
+        console.error(error)
+        return
+      }
+      launch(
+        domain,
+        {
+          proxy: 'localhost:7777',
+          browser: browser,
+          detached: true,
+          options: ['--disable-web-security', '--ignore-certificate-errors'],
+        },
+        function(error, instance) {
+          if (error) {
+            console.error(error)
+            return
+          }
+          console.log(
+            `🎭 ProxyPack browser instance started for ${domain} in ${browser}.`,
+          )
+          // instance.process.unref()
+          // instance.process.stdin.unref()
+          // instance.process.stdout.unref()
+          // instance.process.stderr.unref()
+          instance.on('stop', function(code) {
+            console.log('Instance stopped with exit code:', code)
+          })
+        },
+      )
+    })
+  }
 }
 
 module.exports = openBrowser

--- a/src/browser/openBrowser.js
+++ b/src/browser/openBrowser.js
@@ -1,7 +1,12 @@
 const launcher = require('@james-proxy/james-browser-launcher')
 const openFirefox = require('./firefox')
+const safari = require('./safari')
 
 function openBrowser({ browser, domain }) {
+  if (browser === 'safari') {
+    safari.setupSafariProxy()
+  }
+
   if (browser === 'firefox') {
     openFirefox(domain)
   } else {
@@ -31,6 +36,9 @@ function openBrowser({ browser, domain }) {
           // instance.process.stdout.unref()
           // instance.process.stderr.unref()
           instance.on('stop', function(code) {
+            if (browser === 'safari') {
+              safari.teardownSafariProxy()
+            }
             console.log('Instance stopped with exit code:', code)
           })
         },

--- a/src/browser/safari.js
+++ b/src/browser/safari.js
@@ -1,0 +1,16 @@
+const shell = require('shelljs')
+
+function setupSafariProxy() {
+  shell.exec('networksetup -setwebproxy "Wi-fi" 127.0.0.1 7777')
+  shell.exec('networksetup -setsecurewebproxy "Wi-fi" 127.0.0.1 7777')
+}
+
+function teardownSafariProxy() {
+  shell.exec('networksetup -setwebproxystate "Wi-fi" off')
+  shell.exec('networksetup -setsecurewebproxystate "Wi-fi" off')
+}
+
+module.exports = {
+  setupSafariProxy,
+  teardownSafariProxy,
+}

--- a/src/cli/detect.js
+++ b/src/cli/detect.js
@@ -1,0 +1,6 @@
+var launcher = require('@james-proxy/james-browser-launcher')
+
+launcher.detect(function(available) {
+  console.log('Available browsers:')
+  console.dir(available)
+})

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -2,7 +2,6 @@
 const program = require('safe-commander')
 const browser = require('../browser')
 const install = require('./install')
-const shell = require('shelljs')
 
 program
   .version('0.1.0')

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -1,10 +1,12 @@
 const PROXY_PACK_CONFIG_DIR = `${process.env['HOME']}/.proxypack`
 
 module.exports = {
+  DYNAMIC_IMPORT_URL: 'PROXY_PACK_DYNAMIC_IMPORT_URL',
   LOCAL_WEBPACK_SERVER: {
     PORT: 27777,
     URI: 'https://localhost:27777',
   },
+  PLUGIN_NAME: 'PROXY PACK',
   PROXY_PACK_CONFIG_DIR,
   SSL_CERTS: {
     CA: `${PROXY_PACK_CONFIG_DIR}/proxypack-private-root-ca.crt.pem`,

--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -1,7 +1,6 @@
 const PROXY_PACK_CONFIG_DIR = `${process.env['HOME']}/.proxypack`
 
 module.exports = {
-  DYNAMIC_IMPORT_URL: 'PROXY_PACK_DYNAMIC_IMPORT_URL',
   LOCAL_WEBPACK_SERVER: {
     PORT: 27777,
     URI: 'https://localhost:27777',

--- a/src/proxyServer/index.js
+++ b/src/proxyServer/index.js
@@ -36,7 +36,6 @@ function initProxyServer() {
   const proxyServer = hoxy
     .createServer({ certAuthority: cert.ca })
     .listen(port, status => {
-      // to do change these to getters
       const { externalMappings, localMappings } = state.get()
 
       proxyServer._server.timeout = 15000000

--- a/src/proxyServer/interceptors/domain.js
+++ b/src/proxyServer/interceptors/domain.js
@@ -5,10 +5,7 @@ This interceptor is the first one too get hit in the stack of interceptors.
   - if they are webpack scripts, we proxy them
   - we inject an HTML banner into the page
  */
-const {
-  LOCAL_WEBPACK_SERVER,
-  DYNAMIC_IMPORT_URL,
-} = require('../../constants/config')
+const { LOCAL_WEBPACK_SERVER } = require('../../constants/config')
 const log = require('../../logger/')
 const state = require('../state')
 const Policy = require('csp-parse')
@@ -52,11 +49,6 @@ function init() {
             .map(_entry => {
               return `<script src="${_entry}" proxypack-entry="${scriptGroup}" type="text/javascript"></script>`
             })
-          scriptsForWebpackEntryPoint.unshift(
-            `<script>window.${DYNAMIC_IMPORT_URL}='${
-              LOCAL_WEBPACK_SERVER.URI
-            }/'</script>`,
-          )
           scriptGroups[scriptGroup].replaceWith(scriptsForWebpackEntryPoint)
         }
 

--- a/src/proxyServer/interceptors/domain.js
+++ b/src/proxyServer/interceptors/domain.js
@@ -64,10 +64,6 @@ function init() {
         if (currentPolicy) {
           const policy = new Policy(response.headers['content-security-policy'])
           policy.add('script-src', LOCAL_WEBPACK_SERVER.URI)
-          policy.add('script-src', 'http://localhost:3001')
-          policy.add('connect-src', 'http://localhost:3001')
-          policy.add('connect-src', 'https://beaconapi.helpscout.net')
-
           response.headers['content-security-policy'] = policy.toString()
         }
 

--- a/src/proxyServer/interceptors/domain.js
+++ b/src/proxyServer/interceptors/domain.js
@@ -5,7 +5,10 @@ This interceptor is the first one too get hit in the stack of interceptors.
   - if they are webpack scripts, we proxy them
   - we inject an HTML banner into the page
  */
-const CONFIG = require('../../constants/config')
+const {
+  LOCAL_WEBPACK_SERVER,
+  DYNAMIC_IMPORT_URL,
+} = require('../../constants/config')
 const log = require('../../logger/')
 const state = require('../state')
 const Policy = require('csp-parse')
@@ -50,8 +53,8 @@ function init() {
               return `<script src="${_entry}" proxypack-entry="${scriptGroup}" type="text/javascript"></script>`
             })
           scriptsForWebpackEntryPoint.unshift(
-            `<script>window.proxyPackDynamicUrl='${
-              CONFIG.LOCAL_WEBPACK_SERVER.URI
+            `<script>window.${DYNAMIC_IMPORT_URL}='${
+              LOCAL_WEBPACK_SERVER.URI
             }/'</script>`,
           )
           scriptGroups[scriptGroup].replaceWith(scriptsForWebpackEntryPoint)
@@ -68,7 +71,11 @@ function init() {
         // if a CSP Header exists we merge our local webpack server uri into it
         if (currentPolicy) {
           const policy = new Policy(response.headers['content-security-policy'])
-          policy.add('script-src', CONFIG.LOCAL_WEBPACK_SERVER.URI)
+          policy.add('script-src', LOCAL_WEBPACK_SERVER.URI)
+          policy.add('script-src', 'http://localhost:3001')
+          policy.add('connect-src', 'http://localhost:3001')
+          policy.add('connect-src', 'https://beaconapi.helpscout.net')
+
           response.headers['content-security-policy'] = policy.toString()
         }
 

--- a/src/webpack/index.js
+++ b/src/webpack/index.js
@@ -24,8 +24,8 @@ class ProxyPackPlugin {
     this.getHook = getHook
     this.isLegacyTapable = isLegacyTapable
 
-    const { DYNAMIC_IMPORT_URL, PLUGIN_NAME } = require('../constants/config')
-    this.DYNAMIC_IMPORT_URL = DYNAMIC_IMPORT_URL
+    const { LOCAL_WEBPACK_SERVER, PLUGIN_NAME } = require('../constants/config')
+    this.LOCAL_WEBPACK_SERVER = LOCAL_WEBPACK_SERVER
     this.PLUGIN_NAME = PLUGIN_NAME
 
     this.proxyServer.init({
@@ -65,16 +65,11 @@ class ProxyPackPlugin {
     this.getHook(mainTemplate, 'require-extensions')((source, chunk, hash) => {
       const buildCode = [
         'try {',
-        `  if (typeof ${this.DYNAMIC_IMPORT_URL} !== "string") {`,
-        `    throw new Error("${this.PLUGIN_NAME}: '${
-          this.DYNAMIC_IMPORT_URL
-        }' is not a string or not available at runtime. See https://github.com/agoldis/webpack-require-from#troubleshooting");`,
-        '  }',
-        `  return ${this.DYNAMIC_IMPORT_URL};`,
+        `  return '${this.LOCAL_WEBPACK_SERVER.URI}/';`,
         '} catch (e) {',
         `console.error("${
           this.PLUGIN_NAME
-        }: There was a problem with the dynamic imports url")`,
+        }: There was a problem with the public path.")`,
         '}',
       ].join('\n')
 

--- a/src/webpack/index.js
+++ b/src/webpack/index.js
@@ -10,12 +10,12 @@ class ProxyPackPlugin {
     this.opts = {
       fields: ['entrypoints', 'assetsByChunkName'],
     }
-    /** In the past ProxyPack has blown up in other environments. They seem to
+    /* In the past ProxyPack has blown up in other environments. They seem to
     follow and execute all our files on include. (for example jenkins). I'm not
     sure if it's a webpack problem or a jenkins problem, but it seems like the
     safest way to deal with this is to not require things until we've
     instantiated the plugin
-    **/
+    */
     this.state = require('../proxyServer/state')
     this.webpackServer = require('./server')
     this.proxyServer = require('../proxyServer')

--- a/src/webpack/index.js
+++ b/src/webpack/index.js
@@ -10,11 +10,24 @@ class ProxyPackPlugin {
     this.opts = {
       fields: ['entrypoints', 'assetsByChunkName'],
     }
-    // we load stuff here to make sure that nothing is followed in other
-    // environments, unless this plugin has first been instantiated
+    /** In the past ProxyPack has blown up in other environments. They seem to
+    follow and execute all our files on include. (for example jenkins). I'm not
+    sure if it's a webpack problem or a jenkins problem, but it seems like the
+    safest way to deal with this is to not require things until we've
+    instantiated the plugin
+    **/
     this.state = require('../proxyServer/state')
     this.webpackServer = require('./server')
     this.proxyServer = require('../proxyServer')
+
+    const { getHook, isLegacyTapable } = require('./utils')
+    this.getHook = getHook
+    this.isLegacyTapable = isLegacyTapable
+
+    const { DYNAMIC_IMPORT_URL, PLUGIN_NAME } = require('../constants/config')
+    this.DYNAMIC_IMPORT_URL = DYNAMIC_IMPORT_URL
+    this.PLUGIN_NAME = PLUGIN_NAME
+
     this.proxyServer.init({
       browser,
       domain,
@@ -25,19 +38,56 @@ class ProxyPackPlugin {
     })
   }
 
-  apply(compiler, compilation) {
+  apply(compiler) {
     this.state.set({
       webpackCompilerLocalOutputPath: compiler.options.output.path,
     })
 
-    if (compiler.hooks) {
-      compiler.hooks.emit.tapPromise(
-        'proxypack-plugin',
-        this.emitStats.bind(this),
-      )
-    } else {
-      compiler.plugin('emit', this.emitStats.bind(this))
-    }
+    this.getHook(compiler, 'compilation')(this.replacePublicPath.bind(this))
+    this.getHook(compiler, 'emit')(this.emitStats.bind(this))
+  }
+
+  /* Borrowed from: https://www.npmjs.com/package/webpack-require-from
+    Webpack allows to automatically split and load code using require.ensure or
+   dynamic import import(). Those modules are fetched on-demand when your main
+   bundle is running in browser. Webpack loads the modules (chunks) from a static
+   URL, which is determined by config.output.publicPath of webpack configuration.
+
+   In this case we are overwritting this path to make sure that dynamic imports
+   are resolved via ProxyPack's local node server.
+
+   This url is injected into the web browser, via the domain interceptor,
+   but since webpack compiles this path we also need to make reference to it
+   in source code..
+  */
+  replacePublicPath(compiler) {
+    const { mainTemplate } = compiler
+    this.getHook(mainTemplate, 'require-extensions')((source, chunk, hash) => {
+      const buildCode = [
+        'try {',
+        `  if (typeof ${this.DYNAMIC_IMPORT_URL} !== "string") {`,
+        `    throw new Error("${this.PLUGIN_NAME}: '${
+          this.DYNAMIC_IMPORT_URL
+        }' is not a string or not available at runtime. See https://github.com/agoldis/webpack-require-from#troubleshooting");`,
+        '  }',
+        `  return ${this.DYNAMIC_IMPORT_URL};`,
+        '} catch (e) {',
+        `console.error("${
+          this.PLUGIN_NAME
+        }: There was a problem with the dynamic imports url")`,
+        '}',
+      ].join('\n')
+
+      return [
+        source,
+        `// ProxyPackDynamicUrl`,
+        'Object.defineProperty(' + mainTemplate.requireFn + ', "p", {',
+        '  get: function () {',
+        buildCode,
+        ' }',
+        '})',
+      ].join('\n')
+    })
   }
 
   emitStats(curCompiler, callback) {

--- a/src/webpack/server.js
+++ b/src/webpack/server.js
@@ -2,7 +2,6 @@ const CONFIG = require('../constants/config')
 const getLocalFile = require('../utils/getLocalFile')
 const https = require('https')
 const state = require('../proxyServer/state')
-const fs = require('fs')
 let isInit = false
 
 const init = function() {

--- a/src/webpack/utils.js
+++ b/src/webpack/utils.js
@@ -1,0 +1,44 @@
+const { PLUGIN_NAME } = require('../constants/config')
+const { SyncWaterfallHook } = require('tapable')
+
+function capitalizeFirstLetter(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1)
+}
+
+function dashToCamelCase(value) {
+  const dashed = value.split('-')
+  const cameled = dashed.map((el, i) => {
+    if (i === 0) return el
+    return capitalizeFirstLetter(el)
+  })
+  return cameled.join('')
+}
+
+function fixJsonpScriptHook(tapable) {
+  if (!tapable.hooks.jsonpScript) {
+    tapable.hooks.jsonpScript = new SyncWaterfallHook([
+      'source',
+      'chunk',
+      'hash',
+    ])
+  }
+}
+
+exports.isLegacyTapable = function(tapable) {
+  return tapable.plugin && tapable.plugin.name !== 'deprecated'
+}
+
+exports.getHook = function(tapable, hookName) {
+  if (exports.isLegacyTapable(tapable)) {
+    // webpack < 4
+    return tapable.plugin.bind(tapable, [hookName])
+  }
+
+  fixJsonpScriptHook(tapable)
+
+  const newHookName = dashToCamelCase(hookName)
+  return tapable.hooks[newHookName].tap.bind(
+    tapable.hooks[newHookName],
+    PLUGIN_NAME,
+  )
+}


### PR DESCRIPTION
**Changed how Public Path was Modified in the Webpack Plugin**  

_We were previously using a 3rd Party plugin for this functionality._

Webpack allows to automatically split and load code using require.ensure or dynamic import import(). Those modules are fetched on-demand when your main bundle is running in browser. 

Webpack loads the modules (chunks) from a static URL, which is determined by `config.output.publicPath` of webpack configuration in the compiler.

In this case we are over writing this path to make sure that dynamic imports are resolved via ProxyPack's local node server.

This url is injected into the web browser, via the domain interceptor, but since web pack compiles this path we also need to make reference to it in source code (which is also better because we no longer need to inject it, we just write it into the bundled files).

**Changed how WebPack compiler hooks are handled in ProxyPack**
Since we are adding additional hooks to the compiler process, also added a way to manage hooks if they are legacy < 4 or > 4.

**Fixed Firefox not being able to be opened from CLI**
This was broken when we added a better way to manage SSL. The library we were using can't handle setting that pref.

We now manage FireFox independently by creating a custom profile and passing it when we want to open FireFox from the bin file. This will also make future updates to any FireFox functionality much easier to manage.

**Added a way to set a Proxy in Safari**
ProxyPack was never working in Safari, as there is not a way to setup a Proxy when you open Safari, however there is a way to setup a WebProxy and a SecureWebProxy in MacOSx that Safari respects.

